### PR TITLE
fix: inventory_form.simba scaling issue

### DIFF
--- a/osrs/interfaces/handlers/inventory_form.simba
+++ b/osrs/interfaces/handlers/inventory_form.simba
@@ -170,7 +170,7 @@ begin
     else
       bg.DrawColor := $00FFFF;
     bg.DrawAlpha := $7D;
-    bg.DrawBox(Self.DPISlots[slot]);
+    bg.DrawBox(Self.SlotBoxes[slot]);
     bg.DrawAlpha := $FF;
   end;
 


### PR DESCRIPTION
Fix scaling issue in inventory_form bgimg.

After:
<img width="1147" height="813" alt="image" src="https://github.com/user-attachments/assets/44568ba5-c25a-4ed2-b1bc-5c15ddf7c66d" />


Before:

<img width="1097" height="791" alt="image" src="https://github.com/user-attachments/assets/b15a18ad-4c1c-4446-abdf-8a83ebb4ad54" />
