### PR TITLE
Move close button position in bank interface

### DIFF
--- a/osrs/interfaces/mainscreen/bank.simba
+++ b/osrs/interfaces/mainscreen/bank.simba
@@ -151,6 +151,11 @@ begin
   Self.Scroll.Setup();
   Self.Title.Setup(Self.Bounds);
 
+  Self.Title.CloseButton.X1 := Self.Title.CloseButton.X1 - 5;
+  Self.Title.CloseButton.X2 := Self.Title.CloseButton.X2 + 5;
+  Self.Title.CloseButton.Y1 := Self.Title.CloseButton.Y1 - 5;
+  Self.Title.CloseButton.Y2 := Self.Title.CloseButton.Y2 + 5;
+
   Self.Tabs := TBoxArray.Create(Self.Bounds.TopLeft.Offset(47, 42), 10, 1, 35, 28, [5, 0]);
   Self.SlotBoxes := TBoxArray.Create(Self.Bounds.TopLeft.Offset(57, 77), 8, (Self.Bounds.Height - 135) div 35, 31, 31, [17, 5]);
 


### PR DESCRIPTION
Bank.Close Wasn't working because TRSInterface.IsOpen searches for the 80 points of the border black color.

The bounds of the close button were a bit too small not getting enough color points to go above the 80 thresh-hold in TRSInterface.IsOpen().