### PR TITLE
Add sleep duration in world fetching loop

### DIFF
--- a/osrs/interfaces/gametabs/worldswitcher.simba
+++ b/osrs/interfaces/gametabs/worldswitcher.simba
@@ -379,6 +379,7 @@ begin
   timeout.Start(20 * ONE_SECOND);
 
   repeat
+    Sleep(20,40);
     available := Self.GetWorlds();
     if available = [] then Exit;
 


### PR DESCRIPTION
Super Small Sleep to allow ``Word.Bounds`` to be cached while scrollbar is not moving. Before it was just too fast and would mis-cache ``World.Bounds`` and would click and hop to wrong world.

When it did that, ``Self.WaitSwitch(next) then Exit`` wasn't working because ``self.World <> next``.

The small sleep made it cache the right position and hop to the correct ``next`` world.