### PR TITLE
Adjust key press sleep duration for keyboard input

### DIFF
--- a/utils/input/keyboard.simba
+++ b/utils/input/keyboard.simba
@@ -156,7 +156,7 @@ begin
   for i := 1 to Length(text) do
   begin
     Target.KeySend(text[i]);
-    Sleep(Random(Target.Options.KeyPressMin+10, Target.Options.KeyPressMax+25));
+    Sleep(Random(Target.Options.KeyPressMin+80, Target.Options.KeyPressMax+80));
   end;
 
   Self.LastKey := Target.KeyCodeFromChar(text[Length(text)]);


### PR DESCRIPTION
I bumped the sleeps up a bit. It was not sleeping long enough for the previous keystroke to register.

Part of a duo of fixes for legacy client log ins. Should also fix bank search typo's and mistypes.