### PR TITLE
Update ClearInput to clear input field more effectively

### DIFF
--- a/osrs/interfaces/login/login.simba
+++ b/osrs/interfaces/login/login.simba
@@ -281,15 +281,17 @@ Example:
 WriteLn Login.ClearInput(ERSLoginInput.USERNAME);
 ```
 *)
-function TRSLogin.ClearInput(field: ERSLoginInput): Boolean;
+function TRSLogin.ClearInput(field: ERSLoginInput): Boolean; 
 begin
   if not Self.InputIsFilled(field) then Exit(True);
   if not Self.SelectInput(field) then Exit;
 
-  Keyboard.KeyDown(EKeyCode.BACK);
+  while self.InputIsFilled(field) do
+  Keyboard.KeyPress(EKeyCode.BACK);
+
   Result := SleepUntil(not Self.InputIsFilled(field), RandomMode(100, 50, 1500),  6000);
   Keyboard.KeyUp(EKeyCode.BACK);
-end;
+end;  
 
 (*
 ## Login.FillInput


### PR DESCRIPTION
Without the loop it would hit the key once sleep for 6 seconds, key up and thats it.

Now it deletes the characters until all characters are deleted. Part of a two part fix to legacy client and keyboad. Heres a test snippet with the overrides. Run on any legacy client login screen. 

```Pascal
{$I Wasplib/osrs.simba}   

procedure TKeyboard.Send(text: String); override;
var
  i: Integer;
begin
  for i := 1 to Length(text) do
  begin
    Target.KeySend(text[i]);
    Sleep(Random(Target.Options.KeyPressMin+80, Target.Options.KeyPressMax+80));
  end;

  Self.LastKey := Target.KeyCodeFromChar(text[Length(text)]);
end;

function TRSLogin.ClearInput(field: ERSLoginInput): Boolean; override;
begin
  if not Self.InputIsFilled(field) then Exit(True);
  if not Self.SelectInput(field) then Exit;

  while self.InputIsFilled(field) do
  Keyboard.KeyPress(EKeyCode.BACK);

  Result := SleepUntil(not Self.InputIsFilled(field), RandomMode(100, 50, 1500),  6000);
  Keyboard.KeyUp(EKeyCode.BACK);
end;

begin
  while true do
  begin
    Login.FillInput(ERSLoginInput.USERNAME , 'Two Four Six Eight');
    Sleep(1000);
    Login.ClearInput(ERSLoginInput.USERNAME);
  end;
end; ```