### PR TITLE
Update inventory_layout.simba

### DIFF
--- a/osrs/interfaces/handlers/inventory_layout.simba
+++ b/osrs/interfaces/handlers/inventory_layout.simba
@@ -281,6 +281,7 @@ function TRSInventoryLayout.Reorder(): Boolean;
 var
   i, j: Integer;
   items: array [0..27] of TRSItemArray;
+  tmp: TRSItemArray;
 begin
   for i := 0 to 27 do
   begin
@@ -292,11 +293,16 @@ begin
     for j := i+1 to 27 do
     begin
       if items[j] = [] then
-        items[j] := Inventory.Items.Discover(i);
+        items[j] := Inventory.Items.Discover(j);
 
       if items[j].Contains(Self.Layout.Items[i].Item) then
       begin
         if not Inventory.Slots.Move(j, i) then Exit;
+
+        tmp := items[i];
+        items[i] := items[j];
+        items[j] := tmp;
+
         Break;
       end;
     end;
@@ -304,3 +310,4 @@ begin
 
   Result := True;
 end;
+


### PR DESCRIPTION
The problem is that Reorder() searches slot j but accidentally re-reads slot i, so fix it by changing Inventory.Items.Discover(i) to Inventory.Items.Discover(j) inside the inner loop, optionally swapping the cached slots after a move.