### PR TITLE
Expand close button by 1 pixel.

### DIFF
--- a/osrs/interfaces/mainscreen/silverscreen.simba
+++ b/osrs/interfaces/mainscreen/silverscreen.simba
@@ -67,6 +67,7 @@ begin
   end;
 
   Self.Title.Setup(Self.Bounds);
+  Self.Title.CloseButton := Self.Title.CloseButton.Expand(1);
 
   leftClickBoxes  := TBoxArray.Create(
                  [Self.Bounds.X1 + 10,  Self.Bounds.Y1 + 40],  // anchor


### PR DESCRIPTION
It's the same thing that was happening with bank interface. The bounds were off not triggering the border black color to read that the interface was open.