### PR TITLE
Refactor inventory item comparison and cleanup

### DIFF
--- a/osrs/interfaces/handlers/inventory_layout.simba
+++ b/osrs/interfaces/handlers/inventory_layout.simba
@@ -176,7 +176,7 @@ begin
     for j := 0 to High(items) do
       for n := 0 to High(bitems) do
       begin
-        if items[j] <> bitems[n].Item then Continue;
+        if not SameText(items[j], bitems[n].Item) then Continue;
 
         stack := Inventory.Slots.ReadStack(i);
 
@@ -198,13 +198,6 @@ begin
       end;
 
     if not Bank.Deposit(items[0].ToBankItem(QUANTITY_ALL), True) then
-      Exit;
-  end;
-
-  for i := 0 to High(bitems) do
-  begin
-    if bitems[i].Quantity <= 0 then Continue;
-    if not Bank.Deposit(bitems[i], True) then
       Exit;
   end;
 


### PR DESCRIPTION
Refactor item comparison to use SameText for case-insensitivity and remove redundant bank deposit loop.


Fix 1:
Allow case-insensitive comparisons for items.

Fix 2:
Fix to allow withdrawing actual diff of items.

For example:

Before fix:

Open bank -> deposit 12 karambwans -> withdraw 13 karambwans.

After fix:

Open bank -> withdraw 1 karambwan