### PR TITLE
fix(Bank): prevent crashes on missing bank actions and add support for Bank chest objects

### DIFF
--- a/osrs/forms/antiban_form.simba
+++ b/osrs/forms/antiban_form.simba
@@ -1002,7 +1002,7 @@ end;
 
 
 
-procedure TAntibanFormHelper.OnListKeyDown(sender: TLazObject; var key: Int16; shift: ELazShiftStates);
+procedure TAntibanFormHelper.OnListKeyDown(sender: TLazObject; var key: UInt16; shift: ELazShiftStates);
 begin
   if key <> 46 then
     Exit;

--- a/osrs/forms/inventory_form.simba
+++ b/osrs/forms/inventory_form.simba
@@ -309,7 +309,7 @@ begin
   Self.OnLayoutChange(Self.LayoutCombobox);
 end;
 
-procedure TInventoryFormHelper.OnKeyPress(sender: TLazObject; var key: Int16; shift: ELazShiftStates);
+procedure TInventoryFormHelper.OnKeyPress(sender: TLazObject; var key: UInt16; shift: ELazShiftStates);
 var
   str: String;
   code: EKeyCode;
@@ -389,7 +389,7 @@ procedure TInventoryFormHelper.OnImgKeyDown(sender: TImageBox; var key: UInt16; 
 begin
   if EKeyCode(key) = EKeyCode.SHIFT then
     Self.ShiftDown := True;
-  Self.OnKeyPress(nil, Int16(key), shift);
+  Self.OnKeyPress(nil, key, shift);
 end;
 
 procedure TInventoryFormHelper.OnImgKeyUp(sender: TImageBox; var key: UInt16; shift: ELazShiftStates);

--- a/osrs/interfaces/mainscreen/bank.simba
+++ b/osrs/interfaces/mainscreen/bank.simba
@@ -1382,9 +1382,26 @@ end;
 
 
 procedure TRSBank._SetupMapObjects();
+var
+  chests: TRSObjectArray;
 begin
-  Self.Banks   := TRSObjectArray.Create(Map.Walker, ObjectsJSON.GetByAction('Bank'));
-  Self.Bankers := TRSEntityArray.Create(Map.Walker, NPCsJSON.GetByAction('Bank'));
+  try
+    Self.Banks   := TRSObjectArray.Create(Map.Walker, ObjectsJSON.GetByAction('Bank'));
+  except
+    Self.Banks := [];
+  end;
+
+  try
+    Self.Bankers := TRSEntityArray.Create(Map.Walker, NPCsJSON.GetByAction('Bank'));
+  except
+    Self.Bankers := [];
+  end;
+
+  try
+    chests := TRSObjectArray.Create(Map.Walker, ObjectsJSON.GetByName('Bank chest'));
+    Self.Banks += chests;
+  except
+  end;
 end;
 
 (*
@@ -1425,10 +1442,20 @@ var
   npc: PRSEntity;
   me: TPoint;
 begin
-  if (Self.Banks = []) or (Self.Bankers = []) then
+  if (Length(Self.Banks) = 0) and (Length(Self.Bankers) = 0) then
     Self._SetupMapObjects();
 
+  if (Length(Self.Banks) = 0) and (Length(Self.Bankers) = 0) then
+    Exit(False);
+
   me := Map.Position();
+
+  if Length(Self.Banks) = 0 then
+    Exit(Self.Hover(Self.Bankers[Self.Bankers.ClosestIndex(me)], walk));
+
+  if Length(Self.Bankers) = 0 then
+    Exit(Self.Hover(Self.Banks[Self.Banks.ClosestIndex(me)], walk));
+
   obj := @Self.Banks[Self.Banks.ClosestIndex(me)];
   npc := @Self.Bankers[Self.Bankers.ClosestIndex(me)];
 
@@ -1475,7 +1502,7 @@ begin
     Result := obj.Interact(['Bank B', 'Bank E', 'Bank G', 'Use B']);
 
   if not Result then
-    if not MainScreen.IsUpText('Bank') or not ChooseOption.Select(['Bank B', 'Bank E']) then
+    if not MainScreen.IsUpText('Bank') or not ChooseOption.Select(['Bank B', 'Bank E', 'Use B']) then
       Exit;
 
   obj.Walker^.WaitMoving();
@@ -1509,10 +1536,20 @@ begin
     MSInterface.Close(True);
   end;
 
-  if (Self.Banks = []) or (Self.Bankers = []) then
+  if (Length(Self.Banks) = 0) and (Length(Self.Bankers) = 0) then
     Self._SetupMapObjects();
 
+  if (Length(Self.Banks) = 0) and (Length(Self.Bankers) = 0) then
+    Exit(False);
+
   me := Map.Position();
+
+  if Length(Self.Banks) = 0 then
+    Exit(Self.Open(Self.Bankers[Self.Bankers.ClosestIndex(me)], walk));
+
+  if Length(Self.Bankers) = 0 then
+    Exit(Self.Open(Self.Banks[Self.Banks.ClosestIndex(me)], walk));
+
   obj := @Self.Banks[Self.Banks.ClosestIndex(me)];
   npc := @Self.Bankers[Self.Bankers.ClosestIndex(me)];
 

--- a/osrs/position/map/mapjson.simba
+++ b/osrs/position/map/mapjson.simba
@@ -158,7 +158,7 @@ begin
     end;
 
   if ids = [] then
-    raise GetDebugLn('MapJSON', 'Entry with name ' + name + ' doesn''t exist on the loaded maps.');
+    Exit;
 
   if amount = 0 then
     Exit;
@@ -243,7 +243,7 @@ begin
       end;
 
   if ids = [] then
-    raise GetDebugLn('MapJSON', 'Entry with action ' + action + ' doesn''t exist on the loaded maps.');
+    Exit;
 
   if amount = 0 then
     Exit;


### PR DESCRIPTION
This PR fixes a bug where calling the bare `Bank.Open()` would raise a fatal, script-killing exception if no standard bank booths/NPCs with the 'Bank' action exist in the loaded chunks. It prevents the exception in `mapjson.simba` and introduces a combined lookup in `bank.simba` that automatically aggregates standard booths/NPCs and 'Bank chest' objects, ensuring the closest one is used. It also patches `ChooseOption.Select` to support right-clicking chests.
