### PR TITLE
Fix consumables intersection indexing

### DIFF
--- a/osrs/interfaces/handlers/consumables.simba
+++ b/osrs/interfaces/handlers/consumables.simba
@@ -63,8 +63,8 @@ var
 begin
   for i := 0 to High(other) do
     for j := 0 to High(Self) do
-      if Self[i].Item.Before('(') = other[i] then
-        Result += Self[i];
+      if Self[j].Item.Before('(') = other[i] then
+        Result += Self[j];
 end;
 
 function TRSConsumableItemArray.SortByPoints(lowToHigh: Boolean = False): TRSConsumableItemArray;
@@ -163,8 +163,8 @@ var
 begin
   for i := 0 to High(other) do
     for j := 0 to High(Self) do
-      if Self[i].Item.Before('(') = other[i] then
-        Result += Self[i];
+      if Self[j].Item.Before('(') = other[i] then
+        Result += Self[j];
 end;
 
 function TRSBoostItemArray.SortByPoints(lowToHigh: Boolean = False): TRSBoostItemArray;


### PR DESCRIPTION
Fixes an index mix-up in both consumable intersection helpers.

The loops iterate inventory items with `i` and consumable definitions with `j`, but the comparison/read used `Self[i]`. When the discovered inventory array is longer than the consumable/boost array, this can raise an index out of range exception, e.g. `index:16, low:0, high:15` during `Consumables.Find(ERSSkill.ATTACK)`.

This changes both helpers to compare and return `Self[j]`, matching the inner loop index.